### PR TITLE
Custom container for Ray

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Should get the following response:
 ```
 To validate your AI Keys:
 ```bash
-curl -X POST http://localhost:8000/query \ 
+curl -X POST http://localhost:8000/query \
   -H "Content-Type: application/json" \
   -d '{"question": "What animals work well in clusters?"}'
 ```
@@ -120,7 +120,7 @@ Response:
 
 Query PDF file
 ```bash
-curl -X POST "http://localhost:8000/query" \          
+curl -X POST "http://localhost:8000/query" \
      -H "Content-Type: application/json" \
      -d '{"question":"Summarize the Fox and the Wolf?"}'
 ```
@@ -165,7 +165,6 @@ security_opt:
   - seccomp=unconfined
   - apparmor=unconfined
 ```
-
 ## Troubleshooting
 
 ### Flamegraph shows “Permission denied (os error 13)”

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       GROQ_API_KEY: ${GROQ_API_KEY}
-      # OPENAI_API_KEY: ${OPENAI_API_KEY}   # uncomment if using OpenAI embeddings
+      # OPENAI_API_KEY: ${OPENAI_API_KEY}
       PGVECTOR_SCHEMA: public
       PGVECTOR_TABLE: data_llama_index
     ports:
@@ -36,7 +36,6 @@ services:
       POSTGRES_DB: llamadb
     ports:
       - "5432:5432"
-      # - "5433:5432"   # <- uncomment and use this if 5432 is busy on your host
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:
@@ -49,7 +48,9 @@ services:
       start_period: 5s
 
   ray:
-    image: rayproject/ray:2.35.0-py311-aarch64   # ARM64 build for Apple Silicon
+    build:
+      context: ./infra/ray
+    image: local/ray-with-pyspy:aarch64
     container_name: llama-ray
     command: >
       ray start --head
@@ -60,6 +61,13 @@ services:
       - "6379:6379"   # Redis (Ray internal)
     networks:
       - llama-net
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp=unconfined
+      - apparmor=unconfined
+    environment:
+      RAY_DASHBOARD_ENABLE_PROFILING: "1"
     healthcheck:
       test: ["CMD-SHELL", "ray status || exit 1"]
       interval: 10s

--- a/infra/ray/Dockerfile
+++ b/infra/ray/Dockerfile
@@ -1,0 +1,33 @@
+# ---- Stage 1: build py-spy for ARM64 (Apple Silicon) ----
+FROM --platform=linux/arm64 rust:1.78-bullseye AS builder
+
+# Build a static-ish py-spy binary and place in /out/bin
+RUN cargo install py-spy --version 0.3.14 --locked --root /out
+
+# ---- Stage 2: Ray runtime with py-spy installed ----
+FROM rayproject/ray:2.35.0-py311-aarch64
+
+USER root
+
+# Copy the py-spy binary from the builder
+COPY --from=builder /out/bin/py-spy /usr/local/bin/py-spy
+
+# Make py-spy setuid root; create a sudo shim; add symlink where Ray looks
+RUN set -eux; \
+    PYSPY_BIN="/usr/local/bin/py-spy"; \
+    test -x "${PYSPY_BIN}"; \
+    chown root:root "${PYSPY_BIN}"; \
+    chmod u+s "${PYSPY_BIN}"; \
+    # Minimal sudo shim so 'sudo -n <cmd>' just runs <cmd> (no password)
+    printf '%s\n' '#!/bin/sh' \
+                  'while [ "$1" != "" ] && [ "${1#-}" != "$1" ]; do shift; done' \
+                  'exec "$@"' > /usr/bin/sudo; \
+    chmod 0755 /usr/bin/sudo; \
+    # Ray sometimes invokes this exact path
+    mkdir -p /home/ray/anaconda3/bin; \
+    ln -sf "${PYSPY_BIN}" /home/ray/anaconda3/bin/py-spy; \
+    # Show perms for sanity
+    ls -l "${PYSPY_BIN}" /usr/bin/sudo
+
+# Drop privileges (setuid py-spy will still escalate for profiling)
+USER ray


### PR DESCRIPTION
Allows the ability to see flame graph and other dashboards in Ray

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ray service now built from a custom image with profiling enabled for the dashboard.
  - Added runtime permissions to support safe profiling.
  - Extended health checks for improved startup reliability.

- Documentation
  - Updated Quick Start services into a concise table with links and notes.
  - Added guidance for using a profiling-enabled Ray setup, including required container capabilities.
  - Introduced a comprehensive troubleshooting section covering permissions, volume mapping, and ARM-specific issues.
  - Cleaned up code examples and minor Markdown formatting for consistency.

- Chores
  - Minor comment and formatting adjustments in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->